### PR TITLE
check if window is defined

### DIFF
--- a/can-legacy-view-helpers.js
+++ b/can-legacy-view-helpers.js
@@ -14,7 +14,8 @@ var legacyHelpers = {
 	nodeLists: nodeLists
 };
 
-window.CAN_LEGACY_HELPERS = legacyHelpers;
-
+if(typeof window !== "undefined"){
+    window.CAN_LEGACY_HELPERS = legacyHelpers;
+}
 
 module.exports = legacyHelpers;


### PR DESCRIPTION
to make this PR https://github.com/canjs/can-ejs/pull/43 work on steal-tools too, it is necessary that we check if `window` is defined.

@phillipskevin pls check if this PR is ok and we can make a patch release.