### PR TITLE
Document Fragment to String Bugfix

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -52,7 +52,13 @@ var pendingHookups = [],
 		}
 
 		// Finally, if all else is `false`, `toString()` it.
-		return "" + input;
+		if (input && input.cloneNode) {
+			var div = document.createElement('div');
+			div.appendChild( input.cloneNode(true) );
+			return div.innerHTML;
+		}
+		return input;
+
 	},
 	// Returns escaped/sanatized content for anything other than a live-binding
 	contentEscape = function (txt, tag) {

--- a/src/render.js
+++ b/src/render.js
@@ -57,7 +57,7 @@ var pendingHookups = [],
 			div.appendChild( input.cloneNode(true) );
 			return div.innerHTML;
 		}
-		return input;
+		return "" + input;
 
 	},
 	// Returns escaped/sanatized content for anything other than a live-binding


### PR DESCRIPTION
When contentText encounters a document fragment, the final line converts that document fragment to a string with some buggy type mixing. It would result in "DocumentFragment" actually getting rendered to the page. Instead, if we convert the document fragment to a string via dom innerHTML