### PR TITLE
Can 5 Compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-legacy-view-helpers",
-  "version": "0.6.0",
+  "version": "2.0.0",
   "description": "Legacy view helpers used by can-ejs and can-mustache.",
   "license": "MIT",
   "homepage": "https://github.com/canjs/can-legacy-view-helpers",
@@ -56,17 +56,22 @@
     }
   },
   "dependencies": {
-    "can-ajax": "^1.4.0",
-    "can-cid": "^1.0.3",
-    "can-compute": "^3.1.0",
-    "can-event": "^3.5.0",
-    "can-log": "^1.0.0",
+    "can-ajax": "^2.4.4",
+    "can-cid": "^1.3.1",
+    "can-compute": "^4.1.1",
+    "can-diff": "^1.4.5",
+    "can-dom-data": "^1.0.2",
+    "can-dom-mutate": "^1.3.9",
+    "can-event": "^3.7.7",
+    "can-fragment": "^1.3.1",
+    "can-log": "^1.0.2",
     "can-namespace": "^1.0.0",
-    "can-observation": "^3.3.5",
-    "can-util": "^3.9.0",
-    "can-view-callbacks": "^3.1.0",
-    "can-view-live": "^3.1.0",
-    "can-view-parser": "^3.4.0"
+    "can-observation": "^4.1.3",
+    "can-reflect": "^1.17.11",
+    "can-util": "^3.14.0",
+    "can-view-callbacks": "^4.4.0",
+    "can-view-live": "^4.2.8",
+    "can-view-parser": "^4.1.3"
   },
   "devDependencies": {
     "detect-cyclic-packages": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-legacy-view-helpers",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Legacy view helpers used by can-ejs and can-mustache.",
   "license": "MIT",
   "homepage": "https://github.com/canjs/can-legacy-view-helpers",

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -5,9 +5,10 @@
 //  It allows resolution and callbacks in thread, contrasting with ES5 Promises which always schedule
 //  a microtask for each callback.
 
-var isFunction = require("can-util/js/is-function/is-function"),
-	makeArray = require("can-util/js/make-array/make-array"),
-	each = require("can-util/js/each/each");
+var canReflect = require('can-reflect'),
+	isFunction = canReflect.isFunctionLike,
+	makeArray = canReflect.toArray,
+	each = canReflect.each;
 
 // ====== LEGACY DEFERRED DEFINITION =======
 // _Lightweight, jQuery style deferreds._

--- a/src/node_list.js
+++ b/src/node_list.js
@@ -1,7 +1,8 @@
-var makeArray = require("can-util/js/make-array/make-array");
+var canReflect = require("can-reflect");
+var makeArray = canReflect.toArray;
 var CID = require("can-cid");
-var each = require("can-util/js/each/each");
-var domMutate = require("can-util/dom/mutate/mutate");
+var each = canReflect.each;
+var domMutate = require("can-dom-mutate/node");
 	// ## Helpers
 	// Some browsers don't allow expando properties on HTMLTextNodes
 	// so let's try to assign a custom property, an 'expando' property.

--- a/src/render.js
+++ b/src/render.js
@@ -1,9 +1,20 @@
 var view = require("./view");
 var elements = require("./elements");
-var string = require("can-util/js/string/string");
-var deepAssign = require("can-util/js/deep-assign/deep-assign");
+var deepAssign = require("can-reflect").assignDeep;
 var canCompute = require("can-compute");
 var live = require("./live");
+
+function escape(content) {
+	var isInvalid = content === null || content === undefined || isNaN(content) && '' + content === 'NaN';
+	content = '' + (isInvalid ? '' : content);
+	return content
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&#34;')
+		.replace(/'/g, '&#39;');
+}
+
 /**
  * Helper(s)
  * @hide
@@ -57,13 +68,12 @@ var pendingHookups = [],
 	// Returns escaped/sanatized content for anything other than a live-binding
 	contentEscape = function (txt, tag) {
 		return (typeof txt === 'string' || typeof txt === 'number') ?
-			string.esc(txt) :
+			escape(txt) :
 			contentText(txt, tag);
 	},
 	// A flag to indicate if .txt was called within a live section within an element like the {{name}}
 	// within `<div {{#person}}{{name}}{{/person}}/>`.
-	withinTemplatedSectionWithinAnElement = false,
-	emptyHandler = function () {};
+	withinTemplatedSectionWithinAnElement = false;
 
 var lastHookups;
 
@@ -139,6 +149,7 @@ deepAssign(view, {
 			value,
 			listData,
 			compute,
+			emptyHandler = function () {},
 			unbind = emptyHandler,
 			attributeName;
 

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -6,9 +6,10 @@
 
 var elements = require("./elements");
 var viewCallbacks = require("can-view-callbacks");
-var deepAssign = require("can-util/js/deep-assign/deep-assign");
+var canReflect = require("can-reflect");
+var deepAssign = canReflect.assignDeep;
 var view = require("./view");
-var each = require("can-util/js/each/each");
+var each = canReflect.each;
 /**
  * Helper(s)
  * @hide
@@ -107,7 +108,9 @@ var Scanner = function (options) {
 		 */
 		text: {},
 		tokens: []
-	}, options);
+	});
+	deepAssign(this, options);
+
 	// make sure it's an empty string if it's not
 	this.text.options = this.text.options || "";
 

--- a/src/view.js
+++ b/src/view.js
@@ -6,11 +6,12 @@
 // from the template engine's rendering method
 
 
-var isFunction = require("can-util/js/is-function/is-function"),
-	makeArray =require("can-util/js/make-array/make-array"),
-	deepAssign = require("can-util/js/deep-assign/deep-assign"),
-	canFrag = require("can-util/dom/frag/frag"),
-	each = require("can-util/js/each/each"),
+var canReflect = require('can-reflect'),
+	isFunction = canReflect.isFunctionLike,
+	makeArray = canReflect.toArray,
+	deepAssign = canReflect.assignDeep,
+	canFrag = require("can-fragment"),
+	each = canReflect.each,
 	can = require("can-namespace"),
 	Observation = require("can-observation"),
 	ajax = require("can-ajax/can-ajax"),


### PR DESCRIPTION
Removes usage of `can-util` in favor of `can-reflect` and other modern CanJS replacements.

After merging, a 2.0 release of this repo will be made.